### PR TITLE
Show only first game requiring move

### DIFF
--- a/nova.js
+++ b/nova.js
@@ -16,7 +16,10 @@ function openGames() {
 
     for (var i = 0; i < gamesToOpen.length; i++) {
         chrome.tabs.create({url: "http://nova.gs/game/" + gamesToOpen[i]});
+        if ( open == 'firstGame' )
+            break;
     }
+    
     gamesToOpen = []
     chrome.browserAction.setBadgeText({text: ""});
 }

--- a/options.html
+++ b/options.html
@@ -3,6 +3,8 @@
 <body>
 
 <div>
+<input id="firstGame" type="radio" name="open" value="firstGame">Open first game requiring your move
+<br/>
 <input id="allGames" type="radio" name="open" value="allGames">Open all games requiring move, each in new tab
 <br/>
 <input id="summary" type="radio" name="open" value="summary" checked>Open games summary page


### PR DESCRIPTION
This adds option to open only one tab with the first game from the list of games awaiting your move.
